### PR TITLE
fix(status-code): allow the use of status codes 202 in the API response.

### DIFF
--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -184,7 +184,7 @@ class DownloadManager:
         else:
             res = DownloadManager._REMOTE_RESOURCES_CACHE[resource]
             DBM.g(f"\tQuery '{resource}' loaded from cache!")
-        if res.status_code == 200:
+        if res.status_code in [200, 202]:
             if convertor is None:
                 return res.json()
             else:


### PR DESCRIPTION
## Description

This PR allows the code to handle both `200` and `202` status codes as successful responses from the Wakatime API in the `manager_download.py` file. This change improves the code's robustness, ensuring it continues to work even when the data may not be fully up-to-date, enhancing the user experience.

## Screenshot
![Captura de pantalla 2023-11-21 a las 9 13 19](https://github.com/anmol098/waka-readme-stats/assets/14045148/8ff6c2d3-08d1-4b91-aa4f-cb237b737e3e)
